### PR TITLE
Explicitly use docker.io as the repository hosting

### DIFF
--- a/kubernetes/deploy.sh
+++ b/kubernetes/deploy.sh
@@ -1,5 +1,5 @@
 if [ -z $IMAGE_REPO ] ; then
-    export IMAGE_REPO=epsagon
+    export IMAGE_REPO=docker.io/epsagon
 fi
 if [ -z $IMAGE_NAME ] ; then
     export IMAGE_NAME=auto-inst-mutation-controller


### PR DESCRIPTION
I guess that on some occasions it will solve issues faster for clusters that are not configured to pull from there.